### PR TITLE
Spring boot 1.3.x fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.0.M5</version>
+		<version>1.3.2.RELEASE</version>
 		<relativePath/>
 	</parent>
 	<groupId>com.example</groupId>

--- a/spring-boot-daemon-sample/src/main/dist/bin/setenv.sh
+++ b/spring-boot-daemon-sample/src/main/dist/bin/setenv.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 JSVC_EXECUTABLE="$( which jsvc )"
-JSVC_PID_FILE=/tmp/${dist.project.id}.pid
+JSVC_PID_FILE=/tmp/@dist.project.id@.pid
 
 if [ -z "$JSVC_USER" ]; then
 	JSVC_USER="$USER"
 fi
 
-DIST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+DIST_DIR="$( cd "$( dirname "@BASH_SOURCE[0]@" )/../" && pwd )"
 LIB_DIR="$DIST_DIR/lib"
 CONF_DIR="$DIST_DIR/conf"
 
-SPRING_BOOT_APP=${dist.start.class}
+SPRING_BOOT_APP=@dist.start.class@
 
 JAVA_EXEC="$( which java )"
 JAVA_CLASSPATH="$CONF_DIR:$LIB_DIR/*"

--- a/spring-boot-daemon-sample/src/main/dist/service.xml
+++ b/spring-boot-daemon-sample/src/main/dist/service.xml
@@ -1,24 +1,24 @@
 <service>
-	<id>${dist.project.id}</id>
-	<name>${dist.project.name}</name>
-	<description>${dist.project.description}</description>
+	<id>@dist.project.id@</id>
+	<name>@dist.project.name@</name>
+	<description>@dist.project.description@</description>
 	<workingdirectory>%BASE%\</workingdirectory>
 	<logpath>%BASE%\logs</logpath>
 	<logmode>rotate</logmode>
 
 	<executable>java</executable>
 	<startargument>-Dspring.application.admin.enabled=true</startargument>
-	<startargument>-Dcom.sun.management.jmxremote.port=${dist.jmx.port}</startargument>
+	<startargument>-Dcom.sun.management.jmxremote.port=@dist.jmx.port@</startargument>
 	<startargument>-Dcom.sun.management.jmxremote.authenticate=false</startargument>
 	<startargument>-Dcom.sun.management.jmxremote.ssl=false </startargument>
 	<startargument>-cp</startargument>
 	<startargument>lib/*</startargument>
 	<startargument>com.example.boot.daemon.StartSpringBootService</startargument>
-	<startargument>${dist.start.class}</startargument>
+	<startargument>@dist.start.class@</startargument>
 
 	<stopexecutable>java</stopexecutable>
 	<stopargument>-cp</stopargument>
 	<stopargument>lib/*</stopargument>
 	<stopargument>com.example.boot.daemon.StopSpringBootService</stopargument>
-	<stopargument>${dist.jmx.port}</stopargument>
+	<stopargument>@dist.jmx.port@</stopargument>
 </service>


### PR DESCRIPTION
Hi Stéphane,

I've used this deployment today successfully for our product, thanks a lot. I just had problems with Spring Boot 1.3.x because the default placeholders have been disabled. I've fixed this.
