### PR TITLE
Exclude spring-boot-devtools

### DIFF
--- a/spring-boot-daemon-sample/src/main/assembly/windows.xml
+++ b/spring-boot-daemon-sample/src/main/assembly/windows.xml
@@ -12,6 +12,9 @@
 		<dependencySet>
 			<useProjectArtifact>true</useProjectArtifact>
 			<outputDirectory>lib</outputDirectory>
+			<excludes>
+                		<exclude>org.springframework.boot:spring-boot-devtools</exclude>
+			</excludes>
 		</dependencySet>
 	</dependencySets>
 


### PR DESCRIPTION
Hi Stéphane,
I don't know, if you still maintain those scratches, but I found it useful to exclude the spring-boot-dev from the generated service as it doesn't detect that it is not running in default or development profile.
